### PR TITLE
change the boot order for usb device, before nvme device

### DIFF
--- a/include/configs/rockchip-common.h
+++ b/include/configs/rockchip-common.h
@@ -114,11 +114,11 @@
 
 #define BOOT_TARGET_DEVICES(func) \
 	BOOT_TARGET_MMC(func) \
+	BOOT_TARGET_USB(func) \
 	BOOT_TARGET_NVME(func) \
 	BOOT_TARGET_SCSI(func) \
 	BOOT_TARGET_MTD(func) \
 	BOOT_TARGET_RKNAND(func) \
-	BOOT_TARGET_USB(func) \
 	BOOT_TARGET_PXE(func) \
 	BOOT_TARGET_DHCP(func)
 


### PR DESCRIPTION
let the usb priority higher than nvme, or when if there is a bootable os on nvme, cannot boot from usb