### PR TITLE
sunxi: orangepi4pro: power the M.2 slot from the correct AXP8191 rail (fixes NVMe boot)

### DIFF
--- a/arch/arm/dts/board-uboot.dts
+++ b/arch/arm/dts/board-uboot.dts
@@ -674,7 +674,7 @@
 
 &pcie_rc {
 	pcie1v8_supply = "dldo2";
-	pcie3v3_supply = "dc1sw2";
+	pcie3v3_supply = "dc1sw1";
 	status = "okay";
 };
 


### PR DESCRIPTION
### Problem

U-Boot never enumerates an NVMe drive on Orange Pi 4 Pro (A733 / sun60iw2):

```text
Link up timeout
Speed change timeout
PCIe speed of Gen1
...
Device 0: unknown device
```

`pci` shows only the root bridge `1f6d:abcd` and `nvme scan` is empty, while Linux on the
very same board drives the very same disk at Gen3 without complaint. Booting from NVMe is
therefore impossible: a microSD card is always required.

### Root cause

The PCIe link never leaves LTSSM state **Detect.Quiet** (`PCIE_PL_DEBUG0[5:0] == 0`) — the
root complex never detects a receiver on the lane, because the **M.2 slot has no 3.3V at
all**. `sunxi_pcie_plat_power_on()` switches on whatever `pcie3v3_supply` names, and it
names `dc1sw2`, but this board feeds the slot from `dc1sw1`.

The bug stayed invisible because the kernel device tree marks **both** `dc1sw1` and
`dc1sw2` as `regulator-always-on`, so its regulator core switches both on at boot. The link
therefore comes up exactly when Linux starts — which makes it look as though a microSD card
were needed to "wake" the NVMe drive. In reality the card was only ever needed because
U-Boot read `/boot` from it.

`Link up timeout` was accurate, not premature.

### Evidence (reproducible at the U-Boot prompt, before touching any source)

```text
=> md.l 0x06000728 1
06000728: 003d2200        <- LTSSM = 0x00, Detect.Quiet: no receiver on the lane
=> md.l 0x06400c00 1
06400c00: 00000041        <- LTSSM training enabled, so the link is being attempted
=> i2c dev 0
=> i2c md 0x36 0x11 1
0011: 17                  <- DCDC_POWER_ON_OFF_CTL2: bit 4 (dc1sw2) set, bit 3 (dc1sw1) clear
=> i2c mw 0x36 0x11 0x1f  <- switch dc1sw1 on
=> md.l 0x06400e0c 1
06400e0c: 00000013        <- SMLH_LINK_UP | RDLH_LINK_UP
```

The link trained **by itself**, with no other command: the LTSSM was parked in Detect.Quiet,
saw the termination appear and trained immediately. Clearing bit 4 again
(`i2c mw 0x36 0x11 0x0f`) leaves the link up, so `dc1sw1` alone is sufficient.

PERST was verified correct beforehand and is not involved: PD22 mux `0x02000208` = `0xf11fffff`
(bits 27:24 = `1`, output) and data `0x02000210` = `0x00600000` (bit 22 set, reset released).

Note on the shared voltage register: `dcdc1`, `dc1sw1` and `dc1sw2` share AXP8191 `0x12`,
which already reads `0x17` == 3300mV, so the `set_voltage(3300)` side effect of
`pmu_set_voltage()` is a no-op and does not disturb the parent rail.

### Result

With this one-line change the board boots from NVMe with **no microSD present**:

```text
pcie link up success
PCIe speed of Gen3
Device 0: Vendor: 0x1cc4 Rev: 11.7  Type: Hard Disk
          Capacity: 122104.3 MB = 119.2 GB
Scanning nvme 0:1...
Found U-Boot script /boot/boot.scr
Boot script loaded from nvme 0
```

and Linux reports the link at full speed:

```text
sunxi:pcie-rc-6000000.pcie:[INFO]: pcie is already link up
sunxi:pcie-rc-6000000.pcie:[INFO]: PCIe speed of Gen3
pci 0000:01:00.0: 7.876 Gb/s available PCIe bandwidth, limited by 8.0 GT/s PCIe x1 link
nvme nvme0: pci function 0000:01:00.0
```

No regression: Gen3 and 7.876 Gb/s are exactly what the board achieved before when booting
from microSD.

### Caveats

- **Tested on a single Orange Pi 4 Pro.** The rail assignment is a property of the PCB, not
  of the drive (Detect.Quiet happens before any card-specific negotiation), so it should hold
  for every unit of this board — but I have no schematic and cannot confirm it. Please verify.
- Branch `v2018.05-a733` carries the same value at the same line and presumably needs the
  same fix; I targeted `v2018.05-sun60iw2` because that is what
  `orangepi-build` uses (`BOOTBRANCH='branch:v2018.05-sun60iw2'` in
  `external/config/sources/families/sun60iw2.conf`).
- `pcie1v8_supply = "dldo2"` looks wrong too — the kernel device tree names `bldo1` as
  `pcie1v8-supply` and leaves `dldo2` without any consumer (Linux disables it as unused).
  I left it alone: `bldo1` is already on, so I could not demonstrate that it matters, and I
  did not want to mix an unproven change into this fix.

### Full write-up

Detailed diagnosis, including the false leads (Gen1 / speed-change, PERST, `serdes-reset`,
link-up timeouts, `dldo2`), is here: https://github.com/TblP/orangepi-uboot-fix
